### PR TITLE
When starting a container check the image id 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
             <version>4.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -2,6 +2,7 @@ package com.alexecollins.docker.orchestration;
 
 
 import com.alexecollins.docker.orchestration.model.Credentials;
+import com.alexecollins.docker.orchestration.FileOrchestrator;
 import com.alexecollins.docker.orchestration.model.Id;
 import com.alexecollins.docker.orchestration.model.Ping;
 import com.alexecollins.docker.orchestration.util.Filters;
@@ -40,64 +41,51 @@ public class DockerOrchestrator {
 	private final DockerClient docker;
 	private final Repo repo;
 	private final File workDir;
-	/**
-	 * files to do property filtering on
-	 */
-	private final FileFilter filter;
-	/**
-	 * properties to filter
-	 */
-	private final Properties properties;
 
-	/**
-	 * @deprecated Does not support API version.
-	 */
-	@Deprecated
+    private final FileOrchestrator fileOrchestrator;
+
+    /**
+     * @deprecated Does not support API version.
+     */
+    @Deprecated
 	public DockerOrchestrator(File src, File workDir, String prefix, Credentials credentials) {
 		this(defaultDockerClient(), src, workDir, prefix, credentials, DEFAULT_FILTER, DEFAULT_PROPERTIES);
 	}
 
-	public DockerOrchestrator(DockerClient docker, File src, File workDir, String prefix, Credentials credentials, FileFilter filter, Properties properties) {
-		if (docker == null) {
-			throw new IllegalArgumentException("docker is null");
-		}
-		if (src == null) {
-			throw new IllegalArgumentException("src is null");
-		}
-		if (workDir == null) {
-			throw new IllegalArgumentException("workDir is null");
-		}
-		if (prefix == null) {
-			throw new IllegalArgumentException("prefix is null");
-		}
-		if (filter == null) {
-			throw new IllegalArgumentException("filter is null");
-		}
-		if (properties == null) {
-			throw new IllegalArgumentException("properties is null");
-		}
-		this.docker = docker;
-		try {
-			this.repo = new Repo(docker, prefix, src);
-		} catch (IOException e) {
-			throw new OrchestrationException(e);
-		}
-		this.workDir = workDir;
-
-		if (credentials != null) {
-			docker.setCredentials(credentials.username, credentials.password, credentials.email);
-		}
-		this.filter = filter;
-		this.properties = properties;
-	}
+    public DockerOrchestrator(DockerClient docker, File src, File workDir, String prefix, Credentials credentials, FileFilter filter, Properties properties) {
+        this(docker, new Repo(docker, prefix, src), workDir, new FileOrchestrator(filter, properties), credentials);
+    }
 
 	private static DockerClient defaultDockerClient() {
-		try {
-			return new DockerClient();
-		} catch (DockerException e) {
-			throw new OrchestrationException(e);
-		}
-	}
+        try {
+            return new DockerClient();
+        } catch (DockerException e) {
+            throw new OrchestrationException(e);
+        }
+    }
+
+    public DockerOrchestrator(DockerClient docker,  Repo repo, File workDir, FileOrchestrator fileOrchestrator, Credentials credentials) {
+        if (docker == null) {
+            throw new IllegalArgumentException("docker is null");
+        }
+        if (repo == null) {
+            throw new IllegalArgumentException("repo is null");
+        }
+        if (workDir == null) {
+            throw new IllegalArgumentException("workDir is null");
+        }
+
+
+        this.docker = docker;
+        this.workDir = workDir;
+        this.repo = repo;
+        this.fileOrchestrator = fileOrchestrator;
+
+        if (credentials != null) {
+            docker.setCredentials(credentials.username, credentials.password, credentials.email);
+        }
+
+    }
 
 	public void clean() {
 		for (Id id : repo.ids(true)) {
@@ -161,43 +149,14 @@ public class DockerOrchestrator {
 		}
 	}
 
-	private File prepare(Id id) throws IOException {
-		if (id == null) {
+    private File prepare(Id id) throws IOException {
+        if (id == null) {
 			throw new IllegalArgumentException("id is null");
 		}
-		final File dockerFolder = repo.src(id);
-		final File destDir = new File(workDir, dockerFolder.getName());
+        return fileOrchestrator.prepare(id, repo.src(id), repo.conf(id), workDir);
+    }
 
-		// copy template
-		copyDirectory(dockerFolder, destDir);
 
-		Filters.filter(destDir, filter, properties);
-
-		// copy files
-		for (String file : repo.conf(id).packaging.add) {
-			File fileEntry = new File(filter(file));
-			copyFileEntry(destDir, fileEntry);
-			Filters.filter(fileEntry, filter, properties);
-		}
-
-		return destDir;
-	}
-
-	private String filter(String file) {
-		for (Map.Entry<Object, Object> e : properties.entrySet()) {
-			file = file.replace("${" + e.getKey() + "}", e.getValue().toString());
-		}
-		return file;
-	}
-
-	private void copyFileEntry(final File destDir, File fileEntry) throws IOException {
-		LOGGER.info(" - add " + fileEntry);
-		if (fileEntry.isDirectory()) {
-			copyDirectoryToDirectory(fileEntry, destDir);
-		} else {
-			copyFileToDirectory(fileEntry, destDir);
-		}
-	}
 
 
 	@SuppressWarnings(("DM_DEFAULT_ENCODING"))
@@ -230,40 +189,83 @@ public class DockerOrchestrator {
 		snooze();
 	}
 
-	private void start(final Id id) {
-		if (id == null) {
-			throw new IllegalArgumentException("id is null");
-		}
 
-		// only start
-		try {
-			if (repo.findContainer(id) == null) {
-				LOGGER.info("creating " + id);
-				final ContainerConfig config = new ContainerConfig();
-				config.setImage(repo.findImage(id).getId());
-				/*
-				config.setVolumesFrom(volumesFrom(id).toString().replaceAll("[ \\[\\]]", ""));
+    private void start(final Id id) {
+        if (id == null) {
+            throw new IllegalArgumentException("id is null");
+        }
 
-	            LOGGER.info(" - volumes from " + volumesFrom(id));
-	             */
+        try {
+            Container existingContainer = repo.findContainer(id);
 
-				docker.createContainer(config, repo.containerName(id));
-				snooze();
-			}
+            if (existingContainer == null) {
+                LOGGER.info("No existing container so creating and starting new one");
+                String containerId = createNewContainer(id);
+                startContainer(containerId, id);
 
-			if (!isRunning(id)) {
-				LOGGER.info("starting " + id);
-				docker.startContainer(repo.findContainer(id).getId(), newHostConfig(id));
-			} else {
-				LOGGER.info(id + " already running");
-			}
-		} catch (DockerException e) {
-			throw new OrchestrationException(e);
-		}
+            } else if (!isImageIdFromContainerMatchingProvidedImageId(existingContainer.getId(), id)) {
+                LOGGER.info("image ids dont match, removing container and creating new one from image");
+                docker.removeContainer(existingContainer.getId());
+                startContainer(createNewContainer(id), id);
 
+            } else if(isRunning(id)) {
+                LOGGER.info("Container " + id + " already running");
+
+            } else {
+                LOGGER.info("Starting existing container " + existingContainer.getId());
+                startContainer(existingContainer.getId(), id);
+            }
+
+        } catch (DockerException e) {
+            throw new OrchestrationException(e);
+        }
+    }
+
+    private boolean isImageIdFromContainerMatchingProvidedImageId(String containerId, final Id id) {
+        try {
+            String containerImageId = lookupImageIdFromContainer(containerId);
+            String imageId = repo.findImage(id).getId();
+            return containerImageId.equals(imageId);
+        } catch (DockerException e) {
+            LOGGER.error("Unable to find image with id " + id, e);
+            throw new OrchestrationException(e);
+        }
+
+    }
+
+    private String lookupImageIdFromContainer(String containerId) {
+        try {
+            ContainerInspectResponse containerInspectResponse = docker.inspectContainer(containerId);
+            return containerInspectResponse.getImage();
+        } catch (DockerException e) {
+            LOGGER.error("Unable to inspect container " + containerId, e);
+            throw new OrchestrationException(e);
+        }
+    }
+
+    private void startContainer(String idOfContainerToStart, final Id id) {
+        try {
+            LOGGER.info("starting " + id);
+            docker.startContainer(idOfContainerToStart, newHostConfig(id));
+        } catch (DockerException e) {
+            LOGGER.error("Unable to start container " + idOfContainerToStart, e);
+            throw new OrchestrationException(e);
+        }
+
+    }
+
+
+    private String createNewContainer(Id id) throws DockerException {
+        LOGGER.info("creating " + id);
+        final ContainerConfig config = new ContainerConfig();
+        config.setImage(repo.findImage(id).getId());
+
+		String newContainerId = docker.createContainer(config, repo.containerName(id)).getId();
 		snooze();
-		healthCheck(id);
+        return newContainerId;
 	}
+
+
 
 	private boolean isRunning(Id id) {
 		if (id == null) {throw new IllegalArgumentException("id is null");}
@@ -283,7 +285,7 @@ public class DockerOrchestrator {
 		}
 	}
 
-	private List<Id> volumesFrom(Id id) {
+    private List<Id> volumesFrom(Id id) {
 		final List<Id> ids = new ArrayList<Id>();
 		for (Id from : repo.conf(id).volumesFrom) {
 			ids.add(new Id(repo.findContainer(from).getId()));
@@ -298,10 +300,10 @@ public class DockerOrchestrator {
 		config.setPublishAllPorts(true);
 		config.setLinks(links(id));
 
-		LOGGER.info(" - links " + repo.conf(id).links);
+		LOGGER.info(" - links " + repo.conf(id).getLinks());
 
 		final Ports portBindings = new Ports();
-		for (String e : repo.conf(id).ports) {
+		for (String e : repo.conf(id).getPorts()) {
 
 			final String[] split = e.split(" ");
 
@@ -321,7 +323,7 @@ public class DockerOrchestrator {
 
 	private String[] links(Id id) {
 
-		final List<Id> links = repo.conf(id).links;
+		final List<Id> links = repo.conf(id).getLinks();
 		final String[] out = new String[links.size()];
 		for (int i = 0; i < links.size(); i++) {
 			final String name = repo.findContainer(links.get(i)).getNames()[0];

--- a/src/main/java/com/alexecollins/docker/orchestration/FileOrchestrator.java
+++ b/src/main/java/com/alexecollins/docker/orchestration/FileOrchestrator.java
@@ -1,0 +1,80 @@
+package com.alexecollins.docker.orchestration;
+
+import com.alexecollins.docker.orchestration.model.Conf;
+import com.alexecollins.docker.orchestration.model.Id;
+import com.alexecollins.docker.orchestration.util.Filters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.commons.io.FileUtils.copyDirectory;
+import static org.apache.commons.io.FileUtils.copyDirectoryToDirectory;
+import static org.apache.commons.io.FileUtils.copyFileToDirectory;
+
+public class FileOrchestrator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileOrchestrator.class);
+
+    /**
+     * files to do property filtering on
+     */
+    private final FileFilter filter;
+    /**
+     * properties to filter
+     */
+    private final Properties properties;
+
+    protected FileOrchestrator(FileFilter fileFilter, Properties properties) {
+        if (fileFilter == null) {
+            throw new IllegalArgumentException("filter is null");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("properties is null");
+        }
+
+        this.filter = fileFilter;
+        this.properties = properties;
+    }
+
+    protected File prepare(Id id, File dockerFolder, Conf conf, File workDir) throws IOException {
+        if (id == null) {
+            throw new IllegalArgumentException("id is null");
+        }
+        final File destDir = new File(workDir, dockerFolder.getName());
+        // copy template
+        copyDirectory(dockerFolder, destDir);
+
+        Filters.filter(destDir, filter, properties);
+
+        // copy files
+		for (String file : conf.packaging.add) {
+			File fileEntry = new File(filter(file));
+			copyFileEntry(destDir, fileEntry);
+			Filters.filter(fileEntry, filter, properties);
+		}
+
+        return destDir;
+    }
+
+    private String filter(String file) {
+		for (Map.Entry<Object, Object> e : properties.entrySet()) {
+			file = file.replace("${" + e.getKey() + "}", e.getValue().toString());
+		}
+		return file;
+	}
+
+    private void copyFileEntry(final File destDir, File fileEntry) throws IOException {
+        if (fileEntry.isDirectory()) {
+            LOGGER.info(" - add (dir) " + fileEntry.getAbsolutePath());
+            copyDirectoryToDirectory(fileEntry, destDir);
+        } else {
+            LOGGER.info(" - add (file) " + fileEntry.getAbsolutePath());
+            copyFileToDirectory(fileEntry, destDir);
+        }
+    }
+}

--- a/src/main/java/com/alexecollins/docker/orchestration/Repo.java
+++ b/src/main/java/com/alexecollins/docker/orchestration/Repo.java
@@ -25,7 +25,7 @@ class Repo {
 	private final Map<Id, Conf> confs = new HashMap<Id, Conf>();
 
 	@SuppressWarnings("ConstantConditions")
-	Repo(DockerClient docker, String prefix, File src) throws IOException {
+	Repo(DockerClient docker, String prefix, File src){
 		if (docker == null) {throw new IllegalArgumentException("docker is null");}
 		if (prefix == null) {throw new IllegalArgumentException("prefix is null");}
 		if (src == null) {throw new IllegalArgumentException("src is null");}
@@ -38,8 +38,12 @@ class Repo {
 		if (src.isDirectory()) {
 			for (File file : src.listFiles()) {
 				final File confFile = new File(file, "conf.yml");
-				confs.put(new Id(file.getName()), confFile.length() > 0 ? MAPPER.readValue(confFile, Conf.class) : new Conf());
-			}
+                try {
+                    confs.put(new Id(file.getName()), confFile.length() > 0 ? MAPPER.readValue(confFile, Conf.class) : new Conf());
+                } catch (IOException e) {
+                   throw new OrchestrationException(e);
+                }
+            }
 		}
 	}
 

--- a/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
+++ b/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
@@ -19,4 +19,12 @@ public class Conf {
     public List<Id> volumesFrom = emptyList();
 	@JsonProperty(required = false)
 	public HealthChecks healthChecks = new HealthChecks();
+
+    public List<Id> getLinks() {
+        return links;
+    }
+
+    public List<String> getPorts() {
+        return ports;
+    }
 }

--- a/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorUTest.java
+++ b/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorUTest.java
@@ -1,0 +1,140 @@
+package com.alexecollins.docker.orchestration;
+
+
+import com.alexecollins.docker.orchestration.model.Conf;
+import com.alexecollins.docker.orchestration.model.Credentials;
+import com.alexecollins.docker.orchestration.model.Id;
+import com.kpelykh.docker.client.DockerClient;
+import com.kpelykh.docker.client.DockerException;
+import com.kpelykh.docker.client.model.*;
+import com.sun.jersey.api.client.ClientResponse;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DockerOrchestratorUTest {
+
+    private static final String IMAGE_NAME = "theImage";
+    private static final String IMAGE_ID = "imageId";
+
+    private static final String CONTAINER_NAME = "theContainer";
+    private static final String CONTAINER_ID = "containerId";
+
+    @Mock private DockerClient dockerMock;
+    @Mock private Repo repoMock;
+    @Mock private File fileMock;
+    @Mock private File srcFileMock;
+    @Mock private Credentials credentialsMock;
+    @Mock private Id idMock;
+    @Mock private FileOrchestrator fileOrchestratorMock;
+    @Mock private ClientResponse clientResponseMock;
+    @Mock private Conf confMock;
+    @Mock private Image imageMock;
+    @Mock private ContainerCreateResponse containerCreateResponseMock;
+    @Mock private ContainerConfig containerConfigMock;
+    @Mock private Container containerMock;
+    @Mock private ContainerInspectResponse containerInspectResponseMock;
+
+    private DockerOrchestrator testObj;
+
+    @Before
+    public void setup () throws DockerException, IOException {
+        testObj = new DockerOrchestrator(dockerMock, repoMock, fileMock, fileOrchestratorMock, credentialsMock);
+
+        when(repoMock.src(idMock)).thenReturn(srcFileMock);
+        when(repoMock.conf(idMock)).thenReturn(confMock);
+        when(repoMock.imageName(idMock)).thenReturn(IMAGE_NAME);
+
+        when(repoMock.containerName(idMock)).thenReturn(CONTAINER_NAME);
+        when(imageMock.getId()).thenReturn(IMAGE_NAME);
+        when(confMock.getLinks()).thenReturn(new ArrayList<Id>());
+
+        when(fileOrchestratorMock.prepare(idMock, srcFileMock, confMock, fileMock)).thenReturn(fileMock);
+
+        when(repoMock.ids(false)).thenReturn(Arrays.asList(idMock));
+        when(dockerMock.build(fileMock, IMAGE_NAME)).thenReturn(clientResponseMock);
+        when(dockerMock.createContainer(any(ContainerConfig.class), eq(CONTAINER_NAME))).thenReturn(containerCreateResponseMock);
+        when(clientResponseMock.getEntityInputStream()).thenReturn(IOUtils.toInputStream("Successfully built"));
+        when(containerCreateResponseMock.getId()).thenReturn(CONTAINER_ID);
+    }
+
+
+    @Test
+    public void createAndStartNewContainer() throws DockerException, IOException {
+
+        when(repoMock.findImage(idMock)).thenReturn(null, imageMock);
+
+        testObj.start();
+
+        verify(dockerMock).createContainer(any(ContainerConfig.class), eq(CONTAINER_NAME));
+        verify(dockerMock).startContainer(eq(CONTAINER_ID), any(HostConfig.class));
+    }
+
+    @Test
+    public void startExistingContainerAsImageIdsMatch() throws DockerException, IOException {
+
+        when(repoMock.findImage(idMock)).thenReturn(imageMock);
+        when(repoMock.findContainer(idMock)).thenReturn(containerMock);
+        when(containerMock.getId()).thenReturn(CONTAINER_ID);
+        when(dockerMock.inspectContainer(CONTAINER_ID)).thenReturn(containerInspectResponseMock);
+        when(containerInspectResponseMock.getImage()).thenReturn(IMAGE_ID);
+        when(imageMock.getId()).thenReturn(IMAGE_ID);
+
+        testObj.start();
+
+        verify(dockerMock, times(0)).createContainer(any(ContainerConfig.class), eq(CONTAINER_NAME));
+        verify(dockerMock).startContainer(eq(CONTAINER_ID), any(HostConfig.class));
+    }
+
+    @Test
+    public void containerIsAlreadyRunning() throws DockerException, IOException {
+
+        when(repoMock.findImage(idMock)).thenReturn(imageMock);
+        when(repoMock.findContainer(idMock)).thenReturn(containerMock);
+        when(containerMock.getId()).thenReturn(CONTAINER_ID);
+        when(dockerMock.inspectContainer(CONTAINER_ID)).thenReturn(containerInspectResponseMock);
+        when(containerInspectResponseMock.getImage()).thenReturn(IMAGE_ID);
+        when(imageMock.getId()).thenReturn(IMAGE_ID);
+        when(dockerMock.listContainers(false)).thenReturn(Arrays.asList(containerMock));
+
+        testObj.start();
+
+        verify(dockerMock, times(0)).createContainer(any(ContainerConfig.class), eq(CONTAINER_NAME));
+        verify(dockerMock, times(0)).startContainer(eq(CONTAINER_ID), any(HostConfig.class));
+    }
+
+    @Test
+    public void removeExistingContainerThenCreateAndStartNewOneAsImageIdsDontMatch() throws DockerException, IOException {
+
+        when(repoMock.findImage(idMock)).thenReturn(imageMock);
+        when(repoMock.findContainer(idMock)).thenReturn(containerMock);
+        when(containerMock.getId()).thenReturn(CONTAINER_ID);
+        when(dockerMock.inspectContainer(CONTAINER_ID)).thenReturn(containerInspectResponseMock);
+        when(containerInspectResponseMock.getImage()).thenReturn("A Different Image Id");
+        when(imageMock.getId()).thenReturn(IMAGE_ID);
+
+        testObj.start();
+
+        verify(dockerMock).removeContainer(eq(CONTAINER_ID));
+        verify(dockerMock).createContainer(any(ContainerConfig.class), eq(CONTAINER_NAME));
+        verify(dockerMock).startContainer(eq(CONTAINER_ID), any(HostConfig.class));
+    }
+}


### PR DESCRIPTION
Initially when using the plugin we ran into problems where a old container based on a old image was used just because the name was the same as we were not doing a docker clean. We have since put a docker clean into the appropriate place in our life cycle but it took us a while to find the problem and checking that your not starting a container based on a old image might still have value, what do you think?

I have also refactored file operations into a new class to make unit testing easier as there were no unit tests for the DockerOrchestrator
