### PR TITLE
Fix file move under Windows.

### DIFF
--- a/src/main/java/com/alexecollins/docker/orchestration/util/Filters.java
+++ b/src/main/java/com/alexecollins/docker/orchestration/util/Filters.java
@@ -59,6 +59,8 @@ public final class Filters {
 	}
 
 	private static void move(File from, File to) throws IOException {
+        //renaming over an existing file fails under Windows.
+        to.delete();
 		if (!from.renameTo(to)) {
 			throw new IOException("failed to move " + from + " to " + to);
 		}


### PR DESCRIPTION
Under Windows, renameTo will fail if the destination file already exists.
Deleting the destination first fixes the issue.
