### PR TITLE
Adding "tag" as optional configuration parameter

### DIFF
--- a/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
+++ b/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
+
 import static java.util.Collections.emptyList;
 
 @SuppressWarnings("CanBeFinal")
 public class Conf {
+    @JsonProperty(required = false)
+    private String tag = null;
     @JsonProperty(required = false)
     private List<Id> links = emptyList();
     @JsonProperty(required = false)
@@ -19,6 +23,14 @@ public class Conf {
     private List<Id> volumesFrom = emptyList();
 	@JsonProperty(required = false)
 	private HealthChecks healthChecks = new HealthChecks();
+
+    public boolean hasTag() {
+        return !StringUtils.isBlank(tag);
+    }
+
+    public String getTag() {
+        return tag;
+    }
 
     public List<Id> getLinks() {
         return links;

--- a/src/test/docker/mysql/conf.yml
+++ b/src/test/docker/mysql/conf.yml
@@ -1,2 +1,3 @@
+tag: trog/it-mysql:latest
 ports:
   - 3306

--- a/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorUTest.java
+++ b/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorUTest.java
@@ -45,7 +45,6 @@ public class DockerOrchestratorUTest {
     @Mock private FileOrchestrator fileOrchestratorMock;
     @Mock private ClientResponse clientResponseMock;
     @Mock private Conf confMock;
-    @Mock private Image imageMock;
     @Mock private ContainerCreateResponse containerCreateResponseMock;
     @Mock private ContainerConfig containerConfigMock;
     @Mock private Container containerMock;
@@ -60,9 +59,9 @@ public class DockerOrchestratorUTest {
         when(repoMock.src(idMock)).thenReturn(srcFileMock);
         when(repoMock.conf(idMock)).thenReturn(confMock);
         when(repoMock.imageName(idMock)).thenReturn(IMAGE_NAME);
-
+        when(repoMock.getImageId(idMock)).thenReturn(IMAGE_NAME);
         when(repoMock.containerName(idMock)).thenReturn(CONTAINER_NAME);
-        when(imageMock.getId()).thenReturn(IMAGE_NAME);
+
         when(confMock.getLinks()).thenReturn(new ArrayList<Id>());
 	    when(confMock.getHealthChecks()).thenReturn(new HealthChecks());
 
@@ -79,7 +78,7 @@ public class DockerOrchestratorUTest {
     @Test
     public void createAndStartNewContainer() throws DockerException, IOException {
 
-        when(repoMock.findImage(idMock)).thenReturn(null, imageMock);
+        when(repoMock.imageExists(idMock)).thenReturn(false, true);
 
         testObj.start();
 
@@ -90,12 +89,11 @@ public class DockerOrchestratorUTest {
     @Test
     public void startExistingContainerAsImageIdsMatch() throws DockerException, IOException {
 
-        when(repoMock.findImage(idMock)).thenReturn(imageMock);
+        when(repoMock.getImageId(idMock)).thenReturn(IMAGE_ID);
         when(repoMock.findContainer(idMock)).thenReturn(containerMock);
         when(containerMock.getId()).thenReturn(CONTAINER_ID);
         when(dockerMock.inspectContainer(CONTAINER_ID)).thenReturn(containerInspectResponseMock);
         when(containerInspectResponseMock.getImage()).thenReturn(IMAGE_ID);
-        when(imageMock.getId()).thenReturn(IMAGE_ID);
 
         testObj.start();
 
@@ -106,12 +104,11 @@ public class DockerOrchestratorUTest {
     @Test
     public void containerIsAlreadyRunning() throws DockerException, IOException {
 
-        when(repoMock.findImage(idMock)).thenReturn(imageMock);
+        when(repoMock.getImageId(idMock)).thenReturn(IMAGE_ID);
         when(repoMock.findContainer(idMock)).thenReturn(containerMock);
         when(containerMock.getId()).thenReturn(CONTAINER_ID);
         when(dockerMock.inspectContainer(CONTAINER_ID)).thenReturn(containerInspectResponseMock);
         when(containerInspectResponseMock.getImage()).thenReturn(IMAGE_ID);
-        when(imageMock.getId()).thenReturn(IMAGE_ID);
         when(dockerMock.listContainers(false)).thenReturn(Arrays.asList(containerMock));
 
         testObj.start();
@@ -123,12 +120,11 @@ public class DockerOrchestratorUTest {
     @Test
     public void removeExistingContainerThenCreateAndStartNewOneAsImageIdsDontMatch() throws DockerException, IOException {
 
-        when(repoMock.findImage(idMock)).thenReturn(imageMock);
+        when(repoMock.getImageId(idMock)).thenReturn(IMAGE_ID);
         when(repoMock.findContainer(idMock)).thenReturn(containerMock);
         when(containerMock.getId()).thenReturn(CONTAINER_ID);
         when(dockerMock.inspectContainer(CONTAINER_ID)).thenReturn(containerInspectResponseMock);
         when(containerInspectResponseMock.getImage()).thenReturn("A Different Image Id");
-        when(imageMock.getId()).thenReturn(IMAGE_ID);
 
         testObj.start();
 

--- a/src/test/java/com/alexecollins/docker/orchestration/model/ConfTest.java
+++ b/src/test/java/com/alexecollins/docker/orchestration/model/ConfTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ConfTest {
     private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
@@ -13,6 +14,8 @@ public class ConfTest {
     public void test() throws Exception {
         final Conf conf = MAPPER.readValue(getClass().getResource("/conf.yml"), Conf.class);
 
+        assertNotNull(conf.getTag());
+        assertTrue(conf.hasTag());
         assertNotNull(conf.getLinks());
         assertNotNull(conf.getPackaging());
         assertNotNull(conf.getPorts());

--- a/src/test/resources/conf.yml
+++ b/src/test/resources/conf.yml
@@ -1,3 +1,4 @@
+tag: johnd/corgi-master:latest
 packaging:
   add:
     - target/example-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Enable repo+tag to be explicitly set in conf.yml. When set, old
prefixing behavior no longer applies. When absent, fallback on original behavior.

Change only impacts image name, container names left unchanged.

The other change you will notice is that I have changed the orchestrator
calls used to (a) get image id and (b) determine if an image exists to
use the "inspect" API instead of the "find". The filtering ceased to
work as soon as an image name contained a colon i.e. no results
returned. The undesirable implication of this is that the existence
check relies on catching an exception.
