### PR TITLE
Add support for logging messages from containers that fail to start up

### DIFF
--- a/docker-java-orchestration-core/pom.xml
+++ b/docker-java-orchestration-core/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -84,6 +85,13 @@
             <artifactId>mockito-core</artifactId>
             <version>2.0.5-beta</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- Excluding Hamcrest Core as this library causes a 1.1 -> 1.3 conflict -->
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/util/Logs.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/util/Logs.java
@@ -1,0 +1,41 @@
+package com.alexecollins.docker.orchestration.util;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+public class Logs {
+
+    public static final Byte STDOUT_BYTE = new Byte("0001");
+    public static final Byte STDERR_BYTE = new Byte("0002");
+
+    /**
+     * Parse Docker container logs.
+     *
+     * See: http://docs.docker.com/v1.6/reference/api/docker_remote_api_v1.13/#attach-to-a-container
+     * @param stream
+     * @return
+     * @throws IOException
+     */
+    public static String trimDockerLogHeaders(InputStream stream) throws IOException {
+        String[] dockerContainerLog = IOUtils.toString(stream).split(System.lineSeparator());
+
+        for (int i = 0; i < dockerContainerLog.length; i++) {
+            byte[] stringAsBytes = dockerContainerLog[i].getBytes();
+
+            if (stringAsBytes.length < 8) {
+                continue;
+            }
+
+            if (STDERR_BYTE.equals(stringAsBytes[0]) || STDOUT_BYTE.equals(stringAsBytes[0])) {
+                String prefix = "\t" + (STDERR_BYTE.equals(stringAsBytes[0]) ? "STDERR: " : "STDOUT: ");
+                dockerContainerLog[i] = prefix + new String(Arrays.copyOfRange(stringAsBytes, 8, stringAsBytes.length));
+            }
+        }
+
+        return StringUtils.join(dockerContainerLog, System.lineSeparator());
+    }
+}

--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/util/Logs.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/util/Logs.java
@@ -8,14 +8,48 @@ import java.io.InputStream;
 import java.util.Arrays;
 
 public class Logs {
+    public enum BytePrefix {
+        StdOut(1, "STDOUT"),
+        StdErr(2, "STDERR");
 
-    public static final Byte STDOUT_BYTE = new Byte("0001");
-    public static final Byte STDERR_BYTE = new Byte("0002");
+        private final Byte headerByte;
+        private final String prefix;
+
+        BytePrefix(int headerByte, String prefix) {
+            this.headerByte = (byte) headerByte;
+            this.prefix = prefix;
+        }
+
+        public Byte getHeaderByte() {
+            return headerByte;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public static BytePrefix findFor(Byte bytes) {
+            for (BytePrefix prefix : values())
+                if (bytes.equals(prefix.headerByte))
+                    return prefix;
+
+            return BytePrefix.StdOut;
+        }
+
+        public static boolean isPrefix(Byte bytes) {
+            for (BytePrefix prefix : values())
+                if (bytes.equals(prefix.headerByte))
+                    return true;
+
+            return false;
+        }
+    }
 
     /**
      * Parse Docker container logs.
-     *
+     * <p>
      * See: http://docs.docker.com/v1.6/reference/api/docker_remote_api_v1.13/#attach-to-a-container
+     *
      * @param stream
      * @return
      * @throws IOException
@@ -30,8 +64,8 @@ public class Logs {
                 continue;
             }
 
-            if (STDERR_BYTE.equals(stringAsBytes[0]) || STDOUT_BYTE.equals(stringAsBytes[0])) {
-                String prefix = "\t" + (STDERR_BYTE.equals(stringAsBytes[0]) ? "STDERR: " : "STDOUT: ");
+            if (BytePrefix.isPrefix(stringAsBytes[0])) {
+                String prefix = String.format("\t%s: ", BytePrefix.findFor(stringAsBytes[0]).getPrefix());
                 dockerContainerLog[i] = prefix + new String(Arrays.copyOfRange(stringAsBytes, 8, stringAsBytes.length));
             }
         }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/RepoTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/RepoTest.java
@@ -9,7 +9,9 @@ import org.junit.Test;
 import java.io.File;
 import java.util.*;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 
 public class RepoTest {
@@ -84,6 +86,8 @@ public class RepoTest {
 
     @Test
     public void filesAreNotIncludedInIds() throws Exception {
-        assertEquals(Arrays.asList(appId, filterId), sut.ids(false));
+        List<Id> identifiers = sut.ids(false);
+        assertEquals(identifiers.size(), 2);
+        assertThat(identifiers, hasItems(appId, filterId));
     }
 }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/model/ConfTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/model/ConfTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class ConfTest {
@@ -21,5 +22,8 @@ public class ConfTest {
         assertNotNull(conf.getVolumesFrom());
 
         assertEquals(new Link("foo:bar"), conf.getLinks().get(0));
+
+        assertThat(conf.isLogOnFailure(), is(true));
+        assertThat(conf.getMaxLogLines(), is(123));
     }
 }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/util/LogsTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/util/LogsTest.java
@@ -1,0 +1,90 @@
+package com.alexecollins.docker.orchestration.util;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogsTest {
+
+    @Test
+    public void shouldCompletelyTrimDockerHeaderBytes() throws Exception {
+        String[] fakeLogs = new String[1];
+        byte[] byteArray = new byte[8];
+        byteArray[0] = new Byte("0001");
+        byteArray[1] = new Byte("0000");
+        byteArray[2] = new Byte("0000");
+        byteArray[3] = new Byte("0000");
+        byteArray[4] = new Byte("0000");
+        byteArray[5] = new Byte("0000");
+        byteArray[6] = new Byte("0000");
+        byteArray[7] = new Byte("0000");
+
+        fakeLogs[0] = new String(byteArray);
+
+        String result = Logs.trimDockerLogHeaders(IOUtils.toInputStream(fakeLogs[0], "UTF-8"));
+
+        assertEquals("\tSTDOUT: ", result);
+    }
+
+    @Test
+    public void shouldTrimDockerHeaderBytesAndLeaveCharacter() throws Exception {
+        String[] fakeLogs = new String[1];
+        byte[] byteArray = new byte[9];
+        byteArray[0] = new Byte("0002");
+        byteArray[1] = new Byte("0000");
+        byteArray[2] = new Byte("0000");
+        byteArray[3] = new Byte("0000");
+        byteArray[4] = new Byte("0000");
+        byteArray[5] = new Byte("0000");
+        byteArray[6] = new Byte("0000");
+        byteArray[7] = new Byte("0000");
+        byteArray[8] = new Byte("0065");
+
+        fakeLogs[0] = new String(byteArray);
+
+        String result = Logs.trimDockerLogHeaders(IOUtils.toInputStream(fakeLogs[0], "UTF-8"));
+
+        assertEquals("\tSTDERR: A", result);
+    }
+
+    @Test
+    public void shouldIgnoreNonDockerHeaderBytes() throws Exception {
+        String[] fakeLogs = new String[1];
+        byte[] byteArray = new byte[9];
+        byteArray[0] = new Byte("0065");
+        byteArray[1] = new Byte("0065");
+        byteArray[2] = new Byte("0065");
+        byteArray[3] = new Byte("0065");
+        byteArray[4] = new Byte("0065");
+        byteArray[5] = new Byte("0065");
+        byteArray[6] = new Byte("0065");
+        byteArray[7] = new Byte("0065");
+        byteArray[8] = new Byte("0065");
+
+        fakeLogs[0] = new String(byteArray);
+
+        String result = Logs.trimDockerLogHeaders(IOUtils.toInputStream(fakeLogs[0], "UTF-8"));
+
+        assertEquals("AAAAAAAAA", result);
+    }
+
+    @Test
+    public void shouldNotChangeHeaderIfLessThan8Byes() throws Exception {
+        String[] fakeLogs = new String[1];
+        byte[] byteArray = new byte[7];
+        byteArray[0] = new Byte("0001");
+        byteArray[1] = new Byte("0000");
+        byteArray[2] = new Byte("0000");
+        byteArray[3] = new Byte("0000");
+        byteArray[4] = new Byte("0000");
+        byteArray[5] = new Byte("0000");
+        byteArray[6] = new Byte("0000");
+
+        fakeLogs[0] = new String(byteArray);
+
+        String result = Logs.trimDockerLogHeaders(IOUtils.toInputStream(fakeLogs[0], "UTF-8"));
+
+        assertEquals("\u0001\u0000\u0000\u0000\u0000\u0000\u0000", result);
+    }
+}

--- a/docker-java-orchestration-core/src/test/resources/conf.yml
+++ b/docker-java-orchestration-core/src/test/resources/conf.yml
@@ -9,3 +9,5 @@ volumesFrom:
   - noop
 links:
   - foo:bar
+logOnFailure: true
+maxLogLines: 123

--- a/docker-java-orchestration-core/src/test/resources/logback-test.xml
+++ b/docker-java-orchestration-core/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<configuration debug="false">
+    <root level="info">
+    </root>
+</configuration>

--- a/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
+++ b/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
@@ -25,6 +25,10 @@ public class Conf {
     @JsonProperty
     private int sleep = 0;
     @JsonProperty
+    private boolean logOnFailure = false;
+    @JsonProperty
+    private int maxLogLines = -1;
+    @JsonProperty
     private List<Id> volumesFrom = new ArrayList<Id>();
     @JsonProperty
     private HealthChecks healthChecks = new HealthChecks();
@@ -55,11 +59,11 @@ public class Conf {
     public void setTag(String tag) {
         setTags(Arrays.asList(tag));
     }
-    
+
     public List<String> getTags() {
       return tags;
     }
-    
+
     public void setTags(List<String> tags) {
       this.tags = tags;
     }
@@ -98,5 +102,21 @@ public class Conf {
 
     public void setSleep(int sleep) {
         this.sleep = sleep;
+    }
+
+    public boolean isLogOnFailure() {
+        return logOnFailure;
+    }
+
+    public void setLogOnFailure(boolean logOnFailure) {
+        this.logOnFailure = logOnFailure;
+    }
+
+    public int getMaxLogLines() {
+        return maxLogLines;
+    }
+
+    public void setMaxLogLines(int maxLogLines) {
+        this.maxLogLines = maxLogLines;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,10 +76,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <!-- Using Logback in testing for log output capture (see DockerOrchestratorTest) -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
We wanted a way to get more information from containers that failed to startup from within our CI environment without needing to ssh in and run the 'docker logs' command.

This commit adds a couple of configuration properties to disable/enable this feature and control the amount of log messages returned.

The main change is in the start(id) method, where any exception (including from the healthcheck) will trigger an attempt to log messages from the failed container.

We have attempted to retain the information returned by Docker, where each log message is prefixed with a header that indicates whether the message is from STDERR or STDOUT.

Cheers,

Patrick, Wade, James and Karl