### PR TITLE
Use docker-java NameParser to seperate image name and tag and assign …

### DIFF
--- a/docker-java-orchestration-core/pom.xml
+++ b/docker-java-orchestration-core/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.alexecollins.docker</groupId>
         <artifactId>docker-java-orchestration</artifactId>
         <version>2.8.6-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <!--<relativePath>../pom.xml</relativePath>-->
     </parent>
 
     <artifactId>docker-java-orchestration-core</artifactId>

--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -1,12 +1,7 @@
 package com.alexecollins.docker.orchestration;
 
 
-import com.alexecollins.docker.orchestration.model.BuildFlag;
-import com.alexecollins.docker.orchestration.model.Conf;
-import com.alexecollins.docker.orchestration.model.ContainerConf;
-import com.alexecollins.docker.orchestration.model.HealthChecks;
-import com.alexecollins.docker.orchestration.model.Id;
-import com.alexecollins.docker.orchestration.model.Ping;
+import com.alexecollins.docker.orchestration.model.*;
 import com.alexecollins.docker.orchestration.plugin.api.Plugin;
 import com.alexecollins.docker.orchestration.util.Logs;
 import com.alexecollins.docker.orchestration.util.Pinger;
@@ -14,41 +9,18 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.InternalServerErrorException;
 import com.github.dockerjava.api.NotFoundException;
-import com.github.dockerjava.api.command.BuildImageCmd;
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.command.LogContainerCmd;
-import com.github.dockerjava.api.command.PushImageCmd;
-import com.github.dockerjava.api.model.Bind;
-import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.Image;
-import com.github.dockerjava.api.model.InternetProtocol;
+import com.github.dockerjava.api.command.*;
+import com.github.dockerjava.api.model.*;
 import com.github.dockerjava.api.model.Link;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.core.NameParser;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Properties;
-import java.util.ServiceLoader;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 
@@ -692,10 +664,19 @@ public class DockerOrchestrator {
 
     private void push(Id id) {
         try {
-            PushImageCmd pushImageCmd = docker.pushImageCmd(repo(id));
-            logger.info("Pushing " + id + " (" + pushImageCmd.getName() + ")");
-            InputStream inputStream = pushImageCmd.exec();
-            throwExceptionIfThereIsAnError(inputStream);
+            for (String otherTag : repo.conf(id).getTags()) {
+                NameParser.ReposTag reposTag = NameParser.parseRepositoryTag(otherTag);
+
+                PushImageCmd pushImageCmd = docker.pushImageCmd(reposTag.repos).withAuthConfig(docker.authConfig());
+
+                if (StringUtils.isNotBlank(reposTag.tag)) {
+                    pushImageCmd.withTag(reposTag.tag);
+                }
+                logger.info("Pushing " + id + " (" + otherTag + ")");
+
+                InputStream inputStream = pushImageCmd.exec();
+                throwExceptionIfThereIsAnError(inputStream);
+            }
         } catch (DockerException | IOException e) {
             throw new OrchestrationException(e);
         }
@@ -739,4 +720,5 @@ public class DockerOrchestrator {
         }
         throw new NoSuchElementException("plugin " + pluginClass + " is not loaded");
     }
+
 }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
@@ -55,17 +55,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DockerOrchestratorTest {
@@ -345,6 +335,7 @@ public class DockerOrchestratorTest {
         verify(dockerMock).tagImageCmd(IMAGE_ID, repositoryWithRegistryAndPort, TAG_NAME);
     }
 
+
     @Test
     public void pushImage() {
         testObj.push();
@@ -353,14 +344,65 @@ public class DockerOrchestratorTest {
     }
 
     @Test
-    public void pushImageWithRegistryAndPort() {
+    public void pushImageSimpleNameAndTag() {
+        String name = "myrepository";
+        String nameAndTag = name + ":" + TAG_NAME;
+
+        when(confMock.getTags()).thenReturn(Collections.singletonList(nameAndTag));
+
+        testObj.push();
+
+        verify(dockerMock).pushImageCmd(name);
+        verify(pushImageCmd).withTag(TAG_NAME);
+    }
+
+    @Test
+    public void pushImageWithoutRegistryAndPortAndTag() {
+        String repositoryWithoutRegistry = "mynamespace/myrepository";
+        String repositoryWithoutRegistryAndTag = repositoryWithoutRegistry + ":" + TAG_NAME;
+
+        when(confMock.getTags()).thenReturn(Collections.singletonList(repositoryWithoutRegistryAndTag));
+
+        testObj.push();
+
+        verify(dockerMock).pushImageCmd(repositoryWithoutRegistry);
+        verify(pushImageCmd).withTag(TAG_NAME);
+    }
+
+    @Test
+    public void pushImageWithRegistryAndPortAndTag() {
         String repositoryWithRegistryAndPort = "my.registry.com:5000/mynamespace/myrepository";
 
-        when(repoMock.tag(idMock)).thenReturn(repositoryWithRegistryAndPort + ":" + TAG_NAME);
+        when(confMock.getTags()).thenReturn(Collections.singletonList(repositoryWithRegistryAndPort + ":" + TAG_NAME));
 
         testObj.push();
 
         verify(dockerMock).pushImageCmd(repositoryWithRegistryAndPort);
+        verify(pushImageCmd).withTag(TAG_NAME);
+    }
+
+    @Test
+    public void pushImageWithRegistryAndPort() {
+        String repositoryWithRegistryAndPort = "my.registry.com:5000/mynamespace/myrepository";
+        when(confMock.getTags()).thenReturn(Collections.singletonList(repositoryWithRegistryAndPort));
+
+        testObj.push();
+
+        verify(dockerMock).pushImageCmd(repositoryWithRegistryAndPort);
+        verify(pushImageCmd, never()).withTag(TAG_NAME);
+    }
+
+    @Test
+    public void pushImageWithRegistryAndTag() {
+        String repositoryWithRegistry = "my.registry.com/mynamespace/myrepository";
+        String repositoryWithRegistryAndTag = repositoryWithRegistry + ":" + TAG_NAME;
+
+        when(confMock.getTags()).thenReturn(Collections.singletonList(repositoryWithRegistryAndTag));
+
+        testObj.push();
+
+        verify(dockerMock).pushImageCmd(repositoryWithRegistry);
+        verify(pushImageCmd, times(1)).withTag(TAG_NAME);
     }
 
     @Test


### PR DESCRIPTION
I originally wrote my own ImageName and Tag parser but I found the docker-java `NameParser` which simplified things.

This should also push multiple tags although I haven't written a test for it.