### PR TITLE
Issue 70: NPE with nameless containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Change Log
 2.9.3
 
 * [DMP Issue 67](https://github.com/alexec/docker-maven-plugin/issues/67) Enhancement: Support privileged containers.
+* [DMP Issue 70](https://github.com/alexec/docker-maven-plugin/issues/70) Bug: NPE is thrown with nameless containers.
 
 2.9.0
 

--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -217,7 +217,14 @@ public class DockerOrchestrator {
         final List<Container> matchingContainers = new ArrayList<>();
         for (Container container : docker.listContainersCmd().withShowAll(allContainers).exec()) {
             boolean imageNameMatches = container.getImage().equals(repo.imageName(id));
-            boolean containerNameMatches = asList(container.getNames()).contains(containerName(id));
+            String[] containerNames = container.getNames();
+            if (containerNames == null) {
+                // Every container should have a name, but this is not the case
+                // on Circle CI. Containers with no name are broken residues of
+                // building the image and therefore will be ignored.
+                continue;
+            }
+            boolean containerNameMatches = asList(containerNames).contains(containerName(id));
             if (imageNameMatches || containerNameMatches) {
                 matchingContainers.add(container);
             }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
@@ -420,4 +420,16 @@ public class DockerOrchestratorTest {
 
         verify(createContainerCmdMock).withPrivileged(true);
     }
+
+    @Test
+    public void namelessContainersAreIgnored() {
+        when(containerMock.getNames()).thenReturn(null);
+        when(listContainersCmdMock.exec()).thenReturn(Collections.singletonList(containerMock));
+        when(stopContainerCmdMock.withTimeout(1)).thenReturn(stopContainerCmdMock);
+
+        testObj.stop();
+
+        verify(listContainersCmdMockOnlyRunning).exec();
+        verify(stopContainerCmdMock, times(0)).exec();
+    }
 }


### PR DESCRIPTION
This is a workaround for and resolves alexec/docker-maven-plugin#70.