### PR TITLE
docker-maven-plugin fails on Windows

### DIFF
--- a/docker-java-orchestration-core/pom.xml
+++ b/docker-java-orchestration-core/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.alexecollins.docker</groupId>

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerfileValidatorTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerfileValidatorTest.java
@@ -28,7 +28,7 @@ public class DockerfileValidatorTest {
             validator.validate(new File("src/test/wrongDocker"));
             fail("Validate doesn't detect a wrong formatted Dockerfile");
         } catch (Exception e) {
-            assertEquals("Error while validate Dockerfile src/test/wrongDocker/Dockerfile.", e.getMessage());
+            assertEquals("Error while validate Dockerfile src" + System.getProperty("file.separator") + "test" + System.getProperty("file.separator") + "wrongDocker" + System.getProperty("file.separator") + "Dockerfile.", e.getMessage());
         }
 
     }

--- a/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/StreamRecorder.java
+++ b/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/StreamRecorder.java
@@ -1,0 +1,37 @@
+package com.alexecollins.docker.orchestration.plugin.virtualbox;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+class StreamRecorder extends Thread {
+
+    private InputStream is;
+    private String type;
+
+    private StringBuilder sb = new StringBuilder();
+
+    StreamRecorder(InputStream is, String type) {
+        this.is = is;
+        this.type = type;
+    }
+
+    public void run() {
+
+        try {
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+            String line = null;
+            while ((line = br.readLine()) != null) {
+                sb.append(line);
+            }
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    public String toString() {
+        return sb.toString();
+    }
+}

--- a/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/StreamRecorder.java
+++ b/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/StreamRecorder.java
@@ -25,6 +25,7 @@ class StreamRecorder extends Thread {
             String line = null;
             while ((line = br.readLine()) != null) {
                 sb.append(line);
+                sb.append(System.getProperty("line.separator"));
             }
         } catch (IOException ioe) {
             ioe.printStackTrace();

--- a/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/StreamRecorder.java
+++ b/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/StreamRecorder.java
@@ -19,16 +19,16 @@ class StreamRecorder extends Thread {
 
     public void run() {
 
-        try {
-            InputStreamReader isr = new InputStreamReader(is);
-            BufferedReader br = new BufferedReader(isr);
+        try (InputStreamReader isr = new InputStreamReader(is);
+             BufferedReader br = new BufferedReader(isr)){
+
             String line = null;
             while ((line = br.readLine()) != null) {
                 sb.append(line);
                 sb.append(System.getProperty("line.separator"));
             }
         } catch (IOException ioe) {
-            ioe.printStackTrace();
+            throw new RuntimeException("Problem consuming stream: " + ioe.getMessage(), ioe);
         }
     }
 

--- a/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/VirtualBoxFacade.java
+++ b/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/VirtualBoxFacade.java
@@ -19,21 +19,27 @@ class VirtualBoxFacade {
     private static String exec(String command) {
         LOGGER.debug("Executing " + command);
         int exitCode;
-        String errorOutput;
-        String output;
+        StreamRecorder error;
+        StreamRecorder output;
         try {
             Process process = Runtime.getRuntime().exec(command);
+
+            error = new StreamRecorder(process.getErrorStream(), "ERROR");
+            output = new StreamRecorder(process.getInputStream(), "OUTPUT");
+
+            error.start();
+            output.start();
             exitCode = process.waitFor();
-            errorOutput = asString(process.getErrorStream());
-            output = asString(process.getInputStream());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        LOGGER.debug(output);
+
+        String outputString = output.toString();
+        LOGGER.debug(outputString.toString());
         if (exitCode != 0) {
-            throw new RuntimeException("exit code " + exitCode + ", " + errorOutput);
+            throw new RuntimeException("exit code " + exitCode + ", " + error.toString());
         } else {
-            return output;
+            return outputString;
         }
     }
 

--- a/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/VirtualBoxFacade.java
+++ b/docker-java-orchestration-plugin-boot2docker/src/main/java/com/alexecollins/docker/orchestration/plugin/virtualbox/VirtualBoxFacade.java
@@ -73,7 +73,7 @@ class VirtualBoxFacade {
 
     List<Integer> getPortForwards() {
         String output = exec("VBoxManage showvminfo boot2docker-vm --details");
-        Pattern nicRulePattern = Pattern.compile("NIC . Rule.*host port = ([0-9]*).*");
+        Pattern nicRulePattern = Pattern.compile("NIC\\s.\\sRule.*host\\sport\\s=\\s([0-9]*).*");
         List<Integer> ports = new ArrayList<>();
         for (String line : output.split(System.getProperty("line.separator"))) {
             Matcher matcher = nicRulePattern.matcher(line);


### PR DESCRIPTION
On Windows, when doing Runtime.exec(), the Stderr and Stdout streams need to be drained before doing waitFor. This approach should work across platforms (as per exec() documentation).

This patch allows the plugin to work on Windows with Boot2Docker.