### PR TITLE
Add sslVerify=true/false for self-signed HTTPS healthchecks

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -626,7 +626,7 @@ public class DockerOrchestrator {
             }
             logger.info(String.format("Pinging %s for pattern \"%s\"", uri, ping.getPattern()));
 
-            if (!Pinger.ping(uri, ping.getPattern(), ping.getTimeout())) {
+            if (!Pinger.ping(uri, ping.getPattern(), ping.getTimeout(), ping.isSslVerify())) {
                 throw new OrchestrationException("timeout waiting for " + uri + " for " + ping.getTimeout() + " with pattern " + ping.getPattern());
             }
         }

--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/util/Pinger.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/util/Pinger.java
@@ -1,21 +1,31 @@
 package com.alexecollins.docker.orchestration.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
 import static java.lang.System.currentTimeMillis;
 
 public final class Pinger {
+
+    private static final Logger logger = LoggerFactory.getLogger(Pinger.class);
+
     private Pinger() {
     }
 
-    public static boolean ping(URI uri, Pattern pattern, int timeout) {
+    public static boolean ping(URI uri, Pattern pattern, int timeout, boolean sslVerify) {
         long start = currentTimeMillis();
-        while (!ping(uri, pattern)) {
+        while (!ping(uri, pattern, sslVerify)) {
             if (currentTimeMillis() - start > timeout) {
                 return false;
             }
@@ -29,13 +39,19 @@ public final class Pinger {
     }
 
     public static boolean ping(URI uri, int timeout) {
-        return ping(uri, null, timeout);
+        return ping(uri, null, timeout, true);
     }
 
-    private static boolean ping(URI uri, Pattern pattern) {
+    private static boolean ping(URI uri, Pattern pattern, boolean sslVerify) {
         try {
             final HttpURLConnection c = (HttpURLConnection) uri.toURL().openConnection();
             c.setRequestProperty("Accept", "*/*");
+
+            if (c instanceof HttpsURLConnection && !sslVerify) {
+                ((HttpsURLConnection) c).setSSLSocketFactory(getInsecureSSLSocketFactory());
+                ((HttpsURLConnection) c).setHostnameVerifier(getInsecureHostnameVerifier());
+            }
+
             c.connect();
             try {
                 return c.getResponseCode() == 200 &&
@@ -52,4 +68,40 @@ public final class Pinger {
         return new Scanner(inputStream).useDelimiter("\\A").next();
     }
 
+    private static final SSLSocketFactory getInsecureSSLSocketFactory() {
+        SSLSocketFactory sslSocketFactory = null;
+        try {
+            TrustManager[] tm = new TrustManager[]{new X509TrustManager() {
+                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+
+                public void checkClientTrusted(
+                        java.security.cert.X509Certificate[] certs, String authType) {
+                }
+
+                public void checkServerTrusted(
+                        java.security.cert.X509Certificate[] certs, String authType) {
+                }
+            }};
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, tm, null);
+
+            return context.getSocketFactory();
+        } catch (KeyManagementException e) {
+            logger.error("Failed to initialise SSLContext", e);
+        } catch (NoSuchAlgorithmException e) {
+            logger.error("No TLS algorithm support", e);
+        }
+        return sslSocketFactory;
+    }
+
+    private static HostnameVerifier getInsecureHostnameVerifier() {
+        return new HostnameVerifier() {
+            @Override
+            public boolean verify(String s, SSLSession sslSession) {
+                return true;
+            }
+        };
+    }
 }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/util/PingerIT.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/util/PingerIT.java
@@ -50,12 +50,12 @@ public class PingerIT {
 
     @Test
     public void ensureRegexpMatches() throws Exception {
-        assertTrue(Pinger.ping(httpServerAddress, Pattern.compile("Foo"), timeout));
+        assertTrue(Pinger.ping(httpServerAddress, Pattern.compile("Foo"), timeout, true));
     }
 
     @Test
     public void ensureBadRegexpDoesNotMatch() throws Exception {
-        assertFalse(Pinger.ping(httpServerAddress, Pattern.compile("Bill Murray"), timeout));
+        assertFalse(Pinger.ping(httpServerAddress, Pattern.compile("Bill Murray"), timeout, true));
     }
 
     @Test

--- a/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Ping.java
+++ b/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Ping.java
@@ -12,4 +12,5 @@ public class Ping {
     private URI url;
     private int timeout = 30 * 1000;
     private Pattern pattern = Pattern.compile(".*");
+    private boolean sslVerify = true;
 }


### PR DESCRIPTION
Add a feature toggle (sslVerify) in Ping to allow self-signed certificate HTTPS connections when running health check.  

```
healthChecks:
  pings:
    - url: https://${maven.docker.container.ip}:8446/info
      timeout: 60000
      pattern: \"version\":\"${project.version}\"
      sslVerify: false
```