### PR TITLE
Lookup a container's IP address individually during healthcheck URI

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -1,35 +1,16 @@
 package com.alexecollins.docker.orchestration;
 
 
-import com.alexecollins.docker.orchestration.model.BuildFlag;
-import com.alexecollins.docker.orchestration.model.CleanFlag;
-import com.alexecollins.docker.orchestration.model.Conf;
-import com.alexecollins.docker.orchestration.model.ContainerConf;
-import com.alexecollins.docker.orchestration.model.HealthChecks;
-import com.alexecollins.docker.orchestration.model.Id;
-import com.alexecollins.docker.orchestration.model.LogPattern;
-import com.alexecollins.docker.orchestration.model.Ping;
+import com.alexecollins.docker.orchestration.model.*;
 import com.alexecollins.docker.orchestration.plugin.api.Plugin;
 import com.alexecollins.docker.orchestration.util.Pinger;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.InternalServerErrorException;
 import com.github.dockerjava.api.NotFoundException;
-import com.github.dockerjava.api.command.BuildImageCmd;
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.command.LogContainerCmd;
-import com.github.dockerjava.api.command.PushImageCmd;
-import com.github.dockerjava.api.model.Bind;
-import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.Frame;
-import com.github.dockerjava.api.model.Image;
-import com.github.dockerjava.api.model.InternetProtocol;
+import com.github.dockerjava.api.command.*;
+import com.github.dockerjava.api.model.*;
 import com.github.dockerjava.api.model.Link;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.core.command.FrameReader;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
@@ -37,27 +18,10 @@ import org.apache.commons.lang.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Properties;
-import java.util.ServiceLoader;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 
@@ -760,11 +724,11 @@ public class DockerOrchestrator {
     }
 
     public String getIPAddress(Id id) {
-        if (repo.conf(id).isExposeContainerIp()) {
-            String containerName = repo.containerName(id);
-            InspectContainerResponse containerInspectResponse = docker.inspectContainerCmd(containerName).exec();
+        Container container = findContainer(id);
+        if (container != null && repo.conf(id).isExposeContainerIp()) {
+            InspectContainerResponse containerInspectResponse = docker.inspectContainerCmd(container.getId()).exec();
             return containerInspectResponse.getNetworkSettings().getIpAddress();
-        } else  {
+        } else {
             throw new IllegalArgumentException(id + " container IP address is not exposed");
         }
     }


### PR DESCRIPTION
Hi Alex,

We ran into a timing issue whereby if there were two containers that contained URI healthchecks, the plugin would fail due to the IPAddresses() call during the first healthcheck. This would attempt to find ALL the container IPs, however at that point the second container hasnt yet started and therefore doesnt have a valid IP (yet).

I've submitted a very small fix for it, whereby the URI healthcheck looks up only the IP of the container its starting.