### PR TITLE
Remove associated container volumes on docker:clean

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -467,7 +467,7 @@ public class DockerOrchestrator {
 
     private void removeContainer(Container existingContainer) {
         try {
-            docker.removeContainerCmd(existingContainer.getId()).withForce().exec();
+            docker.removeContainerCmd(existingContainer.getId()).withForce().withRemoveVolumes(true).exec();
         } catch (InternalServerErrorException e) {
             if (permissionErrorTolerant && isPermissionError(e)) {
                 logger.warn(String.format("ignoring %s when removing container as we are configured to be permission error tolerant", e));

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
@@ -171,6 +171,7 @@ public class DockerOrchestratorTest {
         when(dockerMock.removeContainerCmd(CONTAINER_ID)).thenReturn(removeContainerCmdMock);
         when(dockerMock.listImagesCmd()).thenReturn(listImagesCmdMock);
         when(removeContainerCmdMock.withForce()).thenReturn(removeContainerCmdMock);
+        when(removeContainerCmdMock.withRemoveVolumes(anyBoolean())).thenReturn(removeContainerCmdMock);
 
         when(listImagesCmdMock.exec()).thenReturn(Collections.singletonList(imageMock));
 
@@ -244,6 +245,17 @@ public class DockerOrchestratorTest {
 
         verify(createContainerCmdMock, times(0)).exec();
         verify(startContainerCmdMock, times(0)).exec();
+    }
+
+    @Test
+    public void shouldRemoveExistingContainerWithForceDeleteAndVolumeRemoval() throws DockerException, IOException {
+        when(containerInspectResponseMock.getImageId()).thenReturn("A Different Image Id");
+
+        testObj.start();
+
+        verify(removeContainerCmdMock).withForce();
+        verify(removeContainerCmdMock).withRemoveVolumes(true);
+        verify(removeContainerCmdMock).exec();
     }
 
     @Test


### PR DESCRIPTION
I noticed there were a growing number of volumes mounting up (pardon the pun) in my docker /var/lib/docker/vfs/dir, so I have added the v optional parameter on the container remove command.