### PR TITLE
Support for volumes without host path specification

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -66,6 +66,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -689,16 +690,23 @@ public class DockerOrchestrator {
 
         logger.info(" - volumes " + conf.getVolumes());
 
+        final List<Volume> volumes = new ArrayList<>();
         final List<Bind> binds = new ArrayList<>();
-        for (Map.Entry<String, String> entry : conf.getVolumes().entrySet()) {
+        for (Entry<String, String> entry : conf.getVolumes().entrySet()) {
             String volumePath = entry.getKey();
+            Volume volume = new Volume(volumePath);
+            
             String hostPath = entry.getValue();
-            File file = new File(hostPath);
-            String path = file.getAbsolutePath();
-            logger.info(" - volumes " + volumePath + " <- " + path);
-            binds.add(new Bind(path, new Volume(volumePath)));
+            if (hostPath!=null && !hostPath.trim().equals("")){
+            	File file = new File(hostPath);
+            	String path = file.getAbsolutePath();
+            	logger.info(" - volumes " + volumePath + " <- " + path);
+            	binds.add(new Bind(path, volume));
+            } else {
+            	volumes.add(volume);
+            }
         }
-
+        cmd.withVolumes(volumes.toArray(new Volume[volumes.size()]));
         cmd.withBinds(binds.toArray(new Bind[binds.size()]));
 
         cmd.withName(repo.containerName(id));

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/model/ConfTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/model/ConfTest.java
@@ -6,7 +6,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -54,7 +56,11 @@ public class ConfTest {
 
     @Test
     public void volumes() throws Exception {
-        assertEquals(Collections.singletonMap("foo", "bar"), conf.getVolumes());
+    	Map<String, String> volumes = new HashMap<>(2);
+    	volumes.put("foo", "bar");
+    	volumes.put("volume", "");
+    	
+        assertEquals(volumes, conf.getVolumes());
     }
 
     @Test

--- a/docker-java-orchestration-core/src/test/resources/conf.yml
+++ b/docker-java-orchestration-core/src/test/resources/conf.yml
@@ -9,6 +9,7 @@ volumesFrom:
   - noop
 volumes:
   foo: bar
+  volume: 
 links:
   - foo:bar
 logOnFailure: true


### PR DESCRIPTION
Added support to specify volumes without host path. We need this to be able to specify system-dependent host paths or the lack thereof, thus falling back to the default behavior for Dockerfile-defined volumes.

Functionality should actually be a little more sophisticated, but this would break existing config files.