### PR TITLE
Do not force remove

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -271,7 +271,7 @@ public class DockerOrchestrator {
         if (imageId != null) {
             logger.info("Removing image " + imageId);
             try {
-                docker.removeImageCmd(imageId).withForce().exec();
+                docker.removeImageCmd(imageId).exec();
             } catch (DockerException e) {
                 logger.warn(e.getMessage());
             }

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorIT.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorIT.java
@@ -101,7 +101,7 @@ public class DockerOrchestratorIT {
         orchestrator.build(new Id("busybox"));
         orchestrator.clean(new Id("busybox"));
 
-        int expectedSize = expectedImages.size() + (runningOnCircleCi() ? 1 : 0);
+        int expectedSize = expectedImages.size();
         assertEquals(expectedSize, docker.listImagesCmd().exec().size());
     }
 


### PR DESCRIPTION
When building an image without any modification from a remote image then the
image id is the same, which leads to the delete of the remote image when force
is enabled. That is something that is not right in my opinion.