### PR TITLE
Make logPatterns more robust

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/PatternMatchingStartupResultCallback.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/PatternMatchingStartupResultCallback.java
@@ -1,0 +1,94 @@
+package com.alexecollins.docker.orchestration;
+
+import com.alexecollins.docker.orchestration.model.Id;
+import com.alexecollins.docker.orchestration.model.LogPattern;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.command.LogContainerResultCallback;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang.time.StopWatch;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */
+public class PatternMatchingStartupResultCallback extends LogContainerResultCallback {
+
+    private final Logger logger;
+    private final Id id;
+    private final StopWatch watch;
+    private final List<LogPattern> pendingPatterns;
+    private final AtomicReference<State> state = new AtomicReference<>(State.INITIAL);
+
+    public PatternMatchingStartupResultCallback(final Logger logger, final List<LogPattern> pendingPatterns, final Id id) {
+        this.pendingPatterns = Collections.synchronizedList(Lists.newLinkedList(pendingPatterns));
+        this.id = id;
+        this.logger = logger;
+
+        watch = new StopWatch();
+        watch.start();
+    }
+
+    @Override
+    public void onNext(final Frame item) {
+        if (isCanceled()) {
+            return;
+        }
+
+        final String line = new String(item.getPayload()).trim();
+        for (Iterator<LogPattern> iterator = pendingPatterns.iterator(); iterator.hasNext(); ) {
+            LogPattern logPattern = iterator.next();
+            if (logPattern.getPattern().matcher(line).find()) {
+                logger.info("Waited {} for \"{}\"", watch, logPattern.getPattern().toString());
+                iterator.remove();
+            }
+        }
+        if (pendingPatterns.isEmpty()) {
+            watch.stop();
+            onComplete();
+            return;
+        }
+        for (LogPattern logPattern : pendingPatterns) {
+            if (watch.getTime() >= logPattern.getTimeout()) {
+                throw new OrchestrationException(String.format("timeout after %d while waiting for \"%s\" in %s's logs", logPattern.getTimeout(), logPattern.getPattern(), id));
+            }
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (isCanceled() || isComplete()) {
+            return;
+        }
+
+        state.compareAndSet(State.INITIAL, State.COMPLETE);
+
+        if (!pendingPatterns.isEmpty()) {
+            throw new OrchestrationException(String.format("%s's log ended before %s appeared in output", id, DockerOrchestrator.logPatternsToString(pendingPatterns)));
+        }
+
+        super.onComplete();
+    }
+
+    public boolean isComplete() {
+        return state.get() == State.COMPLETE;
+    }
+
+    public void cancel() {
+        state.compareAndSet(State.INITIAL, State.CANCELED);
+    }
+
+    public boolean isCanceled() {
+        return state.get() == State.CANCELED;
+    }
+
+    private enum State {
+        INITIAL, COMPLETE, CANCELED
+    }
+
+}

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/PatternMatchingStartupResultCallbackTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/PatternMatchingStartupResultCallbackTest.java
@@ -1,0 +1,137 @@
+package com.alexecollins.docker.orchestration;
+
+import com.alexecollins.docker.orchestration.model.Id;
+import com.alexecollins.docker.orchestration.model.LogPattern;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+import com.google.common.base.Charsets;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */
+public class PatternMatchingStartupResultCallbackTest {
+
+    private static PatternMatchingStartupResultCallback makeWithPattern(final String pattern, final int timeout) {
+        final LogPattern logPattern = new LogPattern(pattern);
+        logPattern.setTimeout(timeout);
+        return makeWithLogPatterns(Collections.singletonList(logPattern));
+    }
+
+    private static PatternMatchingStartupResultCallback makeWithPattern(final String pattern) {
+        return makeWithPattern(pattern, Integer.MAX_VALUE);
+    }
+
+    private static PatternMatchingStartupResultCallback makeWithLogPatterns(final List<LogPattern> patterns) {
+        final Logger logger = Mockito.mock(Logger.class);
+        return new PatternMatchingStartupResultCallback(logger, patterns, new Id("test"));
+    }
+
+    private static PatternMatchingStartupResultCallback makeEmptyCallbackInstance() {
+        return makeWithLogPatterns(Collections.<LogPattern>emptyList());
+    }
+
+    private static Frame frame(final String value) {
+        return new Frame(StreamType.STDOUT, value.getBytes(Charsets.UTF_8));
+    }
+
+    @Test
+    public void shouldBeCanceledAfterCancel() {
+        final PatternMatchingStartupResultCallback callback = makeEmptyCallbackInstance();
+        assertThat("Should not be canceled", callback.isCanceled(), is(false));
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+
+        callback.cancel();
+
+        assertThat("Should now be canceled", callback.isCanceled(), is(true));
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+    }
+
+    @Test
+    public void shouldBeCompleteAfterCancel() {
+        final PatternMatchingStartupResultCallback callback = makeEmptyCallbackInstance();
+        assertThat("Should not be canceled", callback.isCanceled(), is(false));
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+
+        callback.onComplete();
+
+        assertThat("Should now be complete", callback.isComplete(), is(true));
+        assertThat("Should not be canceled", callback.isCanceled(), is(false));
+    }
+
+    @Test
+    public void shouldNotChangeStateFromCompleteToCancel() {
+        final PatternMatchingStartupResultCallback callback = makeEmptyCallbackInstance();
+        assertThat("Should not be canceled", callback.isCanceled(), is(false));
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+
+        callback.onComplete();
+        callback.cancel();
+
+        assertThat("Should now be complete", callback.isComplete(), is(true));
+        assertThat("Should not be canceled", callback.isCanceled(), is(false));
+    }
+
+    @Test
+    public void shouldNotChangeStateFromCancelToComplete() {
+        final PatternMatchingStartupResultCallback callback = makeEmptyCallbackInstance();
+        assertThat("Should not be canceled", callback.isCanceled(), is(false));
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+
+        callback.cancel();
+        callback.onComplete();
+
+        assertThat("Should now be canceled", callback.isCanceled(), is(true));
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+    }
+
+    @Test
+    public void shouldNotBeCompleteWithoutMatch() {
+        final PatternMatchingStartupResultCallback callback = makeWithPattern("foo");
+
+        callback.onNext(frame("bar"));
+
+        assertThat("Should not be complete", callback.isComplete(), is(false));
+    }
+
+    @Test(expected = OrchestrationException.class)
+    public void shouldThrowOnCompleteWithoutMatch() {
+        final PatternMatchingStartupResultCallback callback = makeWithPattern("foo");
+
+        callback.onComplete();
+    }
+
+    @Test
+    public void shouldBeCompleteWhenMatching() {
+        final PatternMatchingStartupResultCallback callback = makeWithPattern("foo");
+
+        callback.onNext(frame("foo"));
+
+        assertThat("Should now be complete", callback.isComplete(), is(true));
+    }
+
+    @Test(expected = OrchestrationException.class)
+    public void shouldThrowOnTimeout() {
+        final PatternMatchingStartupResultCallback callback = makeWithPattern("foo", -1);
+
+        callback.onNext(frame("bar"));
+    }
+
+    @Test
+    public void shouldNotThrowIfAlreadyCanceled() {
+        final PatternMatchingStartupResultCallback callback = makeWithPattern("foo", -1);
+        callback.cancel();
+        callback.onNext(frame("bar"));
+    }
+
+
+}


### PR DESCRIPTION
Moved the callback to an own class in order to make it easier to reason about.
Made sure that if the timeout happens it will check if it actually completed
sucessfully, which was an issue currently when multiple patterns where
involved.