### PR TITLE
Add 'networkMode' option to Conf

### DIFF
--- a/CONF.md
+++ b/CONF.md
@@ -54,6 +54,8 @@ tag: alex.e.c/app:${project.artifactId}-${project.version}
 enabled: true
 # run in privileged mode
 privileged: true
+# what networkMode to use: bridge, host, none or container (default bridge)
+networkMode: bridge
 ```
 
 

--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -597,6 +597,7 @@ public class DockerOrchestrator {
 
         cmd.withPublishAllPorts(true);
         cmd.withPrivileged(conf.isPrivileged());
+        cmd.withNetworkMode(conf.getNetworkMode());
 
         Link[] links = links(id);
 

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
@@ -515,6 +515,17 @@ public class DockerOrchestratorTest {
     }
 
     @Test
+    public void networkModeConfigurationStartsContainerInSpecifiedNetworkMode() {
+        when(confMock.getNetworkMode()).thenReturn("host");
+        mockRunningIdMock();
+
+        testObj.start();
+
+        verify(createContainerCmdMock).withNetworkMode("host");
+
+    }
+
+    @Test
     public void namelessContainersAreIgnored() {
         when(containerMock.getNames()).thenReturn(null);
         when(listContainersCmdMock.exec()).thenReturn(Collections.singletonList(containerMock));

--- a/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
+++ b/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
@@ -38,6 +38,7 @@ public class Conf {
     private boolean exposeContainerIp = true;
     private List<String> extraHosts = new ArrayList<>();
     private boolean privileged;
+    private String networkMode = "bridge";
 
     public Conf() {
     }


### PR DESCRIPTION
This commits adds a new option to the Conf model called 'networkMode'.
It is used to set the mode of the container network (equivalent to
'docker run --net=')