### PR TITLE
Improve Image Selection

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -443,7 +443,7 @@ public class DockerOrchestrator {
         List<Image> images = docker.listImagesCmd().exec();
         for (Image i : images) {
             for (String tag : i.getRepoTags()) {
-                if (tag.startsWith(imageTag)) {
+                if (tag.startsWith(imageTag + ":")) {
                     logger.debug("Using {} ({}) for {}. It matches (enough) to {}.", new Object[]{
                             i.getId(),
                             tag,

--- a/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
+++ b/docker-java-orchestration-core/src/test/java/com/alexecollins/docker/orchestration/DockerOrchestratorTest.java
@@ -211,7 +211,7 @@ public class DockerOrchestratorTest {
 
         when(repoMock.ids(false)).thenReturn(Collections.singletonList(idMock));
         when(repoMock.ids(true)).thenReturn(Collections.singletonList(idMock));
-        when(repoMock.tag(any(Id.class))).thenReturn(IMAGE_NAME + ":" + TAG_NAME);
+        when(repoMock.tag(any(Id.class))).thenReturn(IMAGE_NAME);
 
         when(dockerMock.removeImageCmd(anyString())).thenReturn(removeImageCmdMock);
         when(removeImageCmdMock.withForce(true)).thenReturn(removeImageCmdMock);
@@ -267,7 +267,7 @@ public class DockerOrchestratorTest {
         when(listImagesCmdMock.exec()).thenReturn(Collections.singletonList(imageMock));
 
         when(imageMock.getId()).thenReturn(IMAGE_ID);
-        when(imageMock.getRepoTags()).thenReturn(new String[]{IMAGE_NAME + ":" + TAG_NAME});
+        when(imageMock.getRepoTags()).thenReturn(new String[]{IMAGE_NAME + "2:" + TAG_NAME, IMAGE_NAME + ":" + TAG_NAME});
 
         when(dockerMock.listContainersCmd()).thenReturn(listContainersCmdMock);
         when(listContainersCmdMock.withShowAll(true)).thenReturn(listContainersCmdMock);

--- a/docker-java-orchestration-plugin-boot2docker/src/test/java/com/alexecollins/docker/orchestration/plugin/virtualbox/VirtualBoxFacadeTest.java
+++ b/docker-java-orchestration-plugin-boot2docker/src/test/java/com/alexecollins/docker/orchestration/plugin/virtualbox/VirtualBoxFacadeTest.java
@@ -18,7 +18,8 @@ public class VirtualBoxFacadeTest {
     public void canParseVmNames() throws Exception {
 
         when(commandExecutor.exec(anyString())).thenReturn(
-                "\"db2-972-exc-5_default_1433864805042_17400\" {e7fbeef6-f9f9-4c5a-a57a-9571c1fe7e67}\n" +
+                "\"db2-972-exc-5_default_1433864805042_17400\" {e7fbeef6-f9f9-4c5a-a57a-9571c1fe7e67}" +
+                        System.getProperty("line.separator") +
                         "\"default\" {90d48200-4395-4346-83af-8cbd537e7009}"
         );
 


### PR DESCRIPTION
Docker images are sometimes incorrectly matched when two images exist in the same maven project and are named in a manner where one name forms the prefix of the other. For example, two images postgres and postgres2 will cause a problem where the image for postgres2 will be selected instead of postgres. The added colon represents the separator between the name and the version, which ensure that the match goes to the end of the name, resulting in a more accurate image selection.