### PR TITLE
Fix null pointer on untagged images

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -400,10 +400,12 @@ public class DockerOrchestrator {
         logger.debug("Converting {} ({}) to image id.", id, imageTag);
         List<Image> images = docker.listImagesCmd().exec();
         for (Image image : images) {
-            for (String tag : image.getRepoTags()) {
-                if (imageTag.contains(":") && tag.equals(imageTag) || tag.startsWith(imageTag + ":")) {
-                    logger.debug("Using {} ({}) for {}. It matches (enough) to {}.", image.getId(), tag, id, imageTag);
-                    return image.getId();
+            if (image.getRepoTags() != null ) {
+                for (String tag : image.getRepoTags()) {
+                    if (imageTag.contains(":") && tag.equals(imageTag) || tag.startsWith(imageTag + ":")) {
+                        logger.debug("Using {} ({}) for {}. It matches (enough) to {}.", image.getId(), tag, id, imageTag);
+                        return image.getId();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Apparently the getRepoTags can be null when the image is not tagged at all.
This patch fixes a null pointer issue for me.