### PR TITLE
Added support to configure hostname for the docker host

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -26,6 +26,7 @@ import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -666,6 +667,10 @@ public class DockerOrchestrator {
         }
         cmd.withVolumes(volumes.toArray(new Volume[volumes.size()]));
         cmd.withBinds(binds.toArray(new Bind[binds.size()]));
+
+        if(StringUtils.isEmpty(conf.getHostname())){
+            cmd.withHostName(conf.getHostname());
+        }
 
         cmd.withName(repo.containerName(id));
         logger.info(" - env " + conf.getEnv());

--- a/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
+++ b/docker-java-orchestration-model/src/main/java/com/alexecollins/docker/orchestration/model/Conf.java
@@ -40,6 +40,11 @@ public class Conf {
     private boolean privileged;
     private String networkMode = "bridge";
 
+    /*
+    * configure hostname for the docker host
+    */
+    private String hostname = null;
+
     public Conf() {
     }
 


### PR DESCRIPTION
In the conf.yml file we can do below which will associate hostname to the docker host 

Reason to add, ZK broadcasts the kafka broker and with docker having kafa/zk in one container and it uses the hostname of the machine and in docker default value assigned by docker is a random value and tough to do the integration testing so made this change to have a static value which can be leveraged in the code.
eg: conf.yml file
ports:
  - 9092 9092
sleep: 1000
hostname: foo.bar
