### PR TITLE
Reinstate container logging for when an exception occurs during 'start'

### DIFF
--- a/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
+++ b/docker-java-orchestration-core/src/main/java/com/alexecollins/docker/orchestration/DockerOrchestrator.java
@@ -483,15 +483,15 @@ public class DockerOrchestrator {
         } catch (Exception e) {
             logger.error("Error starting container with id " + id + ": " + e.getMessage());
             throw new OrchestrationException(e);
+        } finally {
+            final Container container = findContainer(id);
+            if (container == null) {
+                logger.error("Could not find container with id {}. No logs can be obtained", id);
+            } else {
+                final Tail tail = tailFactory.newTail(docker, container, logger);
+                tail.start();
+            }
         }
-
-        final Container container = findContainer(id);
-        if (container == null) {
-            throw new OrchestrationException("Could not find container with id " + id);
-        }
-
-        final Tail tail = tailFactory.newTail(docker, container, logger);
-        tail.start();
     }
 
     private Container findContainer(Id id) {


### PR DESCRIPTION
Partially revert a change in 7935273df794dec81442a47806a13c8af91d5a5e whereby the container logging logic was pulled out of the finally clause so it no longer logged if an exception occurred.

The null check has been retained, but if the container can't be found at this point the error is logged rather than another exception being thrown, on the basis that this gets in the way of diagnosing the original exception and it doesn't seem necessary to throw an exception simply because we can't obtain logs.